### PR TITLE
タブレット用に修正

### DIFF
--- a/dist/assets/main.css
+++ b/dist/assets/main.css
@@ -1,1 +1,1045 @@
-*{box-sizing:border-box;outline:0}html{margin:0;padding:0}body{margin:0;padding:40px 40px 100px;color:#333;font:normal 300 17px/1.76 "Noto Sans JP",sans-serif;letter-spacing:.053em}a{color:#333;text-decoration:none;border-bottom:1px solid #333}a:active,a:hover,a:link,a:visited{color:#333}a[href^=http],a[href^=skype]{padding-right:14px;background-image:url(/assets/link.png);background-repeat:no-repeat;background-position:right center;background-size:12px 7px}iframe{border:none}hr.line{margin:30px 0;border:none;width:100%;height:2px;background-image:url(/assets/line.png)}#dots{position:fixed;left:0;top:0;width:100%;height:100%;overflow:hidden;opacity:.8;z-index:1000;pointer-events:none}#container{position:relative;max-width:960px;margin:0 auto}.notfound{display:block;text-align:center;margin:200px 0}.clearfix:after,.clearfix:before{content:" ";display:table}.clearfix:after{clear:both}#header{position:relative;z-index:2000;margin:20px 0 105px;display:-ms-flexbox;display:flex;-ms-flex-pack:justify;justify-content:space-between}#logo a{border:none}#logo a img{width:180px;margin-top:5px}#menu{padding:5px 2px 0;margin:0 -30px}#menu li{display:inline-block;list-style:none;font:normal 300 18px acumin-pro,sans-serif;margin:0 29px}#menu li .dot{display:inline-block;width:10px;height:10px;border-radius:10px;background-color:#000;transform:translateY(-15px)}#menu li .dot.inactive{visibility:hidden}#menu li a{color:#333;text-decoration:none;border:none}#floating-menu{position:fixed;display:table;z-index:3000;left:0;top:0;width:100%;height:80px;padding-bottom:4px;text-align:center;transition:transform .1s ease-out}#floating-menu>div{display:table-cell;padding:0;margin:0;width:100%;vertical-align:middle;background-color:rgba(255,255,255,.9)}#floating-menu>div a{display:inline-block;list-style:none;font:normal 300 18px acumin-pro,sans-serif;margin:0 40px;border:none}#floating-menu>div a .dot{display:inline-block;width:10px;height:10px;border-radius:10px;background-color:#000;transform:translateY(-15px)}#floating-menu>div a .dot.inactive{visibility:hidden}#floating-menu.close{transform:translateY(-100%)}#menu-button{position:fixed;z-index:3100;right:22px;top:22px;width:46px;height:40px;padding:10px;cursor:pointer;transform:translateY(-60px);transition:transform .2s ease-out;-webkit-tap-highlight-color:transparent}#menu-button.enable{transform:translateY(0)}#menu-button div{position:absolute;border:2px solid #333;border-radius:4px;width:16px;transition:all .1s ease-out}#menu-button div.upper-left{left:10px;top:10px;transform-origin:left top}#menu-button div.upper-right{right:10px;top:10px;transform-origin:right top}#menu-button div.middle{width:26px;left:10px;top:18px}#menu-button div.lower-left{left:10px;bottom:10px;transform-origin:left bottom}#menu-button div.lower-right{right:10px;bottom:10px;transform-origin:right bottom}#menu-button.close div{transition:all .1s ease-out}#menu-button.close .upper-left{transform:translateX(6px) rotate(45deg)}#menu-button.close .upper-right{transform:translateX(-6px) rotate(-45deg)}#menu-button.close .middle{transform:scaleX(0)}#menu-button.close .lower-left{transform:translateX(6px) rotate(-45deg)}#menu-button.close .lower-right{transform:translateX(-6px) rotate(45deg)}#footer .copyright{position:fixed;left:20px;bottom:20px;transform-origin:left bottom;transform:scale(0.5,.5)}#footer .buttons{position:fixed;z-index:auto;right:20px;bottom:20px;text-align:right;font-size:0;transform-origin:right bottom;transform:scale(0.5,.5)}#footer .buttons:hover{z-index:2000}#footer .buttons button{display:block;width:68px;height:68px;background:0 0;border:none;cursor:pointer;margin:auto 0 auto auto}#footer .buttons .wallpaper{margin-bottom:40px;background-position:right;background-image:url(/assets/wallpaper.png)}#footer .buttons .wallpaper:hover{width:466px;background-image:url(/assets/wallpaper-hover.png)}#footer .buttons .facebook{margin-bottom:20px;background-image:url(/assets/facebook.png)}#footer .buttons .facebook:hover{background-image:url(/assets/facebook-hover.png)}#footer .buttons .twitter{margin-bottom:100px;background-image:url(/assets/twitter.png)}#footer .buttons .twitter:hover{background-image:url(/assets/twitter-hover.png)}#footer .buttons .top{background-image:url(/assets/top.png)}#footer .buttons .top:hover{background-image:url(/assets/top-hover.png)}.entry{padding:0 30px;background-repeat:no-repeat;background-position:center top}.entry.with-image{padding-top:30px}.entry .featured-image{height:396px}.entry .inner{position:relative;z-index:auto;padding:40px 62px;background-repeat:no-repeat;background-position:-34px -34px;background-color:transparent;border:4px solid transparent;border-radius:10px;overflow:hidden;transform:translateZ(0)}.entry .inner h1.title{margin:32px auto 12px;font-weight:400;font-size:22px;text-align:center}.entry .inner .date{display:block;margin-bottom:82px;font:normal 300 15px acumin-pro,sans-serif;text-align:center}.entry .inner .date a{border:none}.entry .inner .body{margin:0 auto;padding:0;font-weight:300}.entry .inner .body iframe,.entry .inner .body img{width:100%}.entry .inner .body p,.entry .inner .body table{margin:20px 0;word-wrap:break-word}.entry .inner .body .award td,.entry .inner .body .award th,.entry .inner .body .credit td,.entry .inner .body .credit th,.entry .inner .body .tags td,.entry .inner .body .tags th{font-size:15px;vertical-align:baseline}.entry .inner .body .award th,.entry .inner .body .credit th,.entry .inner .body .tags th{padding-right:25px;font:normal 600 15px acumin-pro,sans-serif;text-align:left}.entry .inner .body .award td,.entry .inner .body .award th{padding-bottom:10px;vertical-align:middle}.entry .inner .body .award img{width:auto;max-height:40px;margin-right:20px}.entry .inner .body .credit td>span{display:block}.entry .inner .body .credit h2{font:normal 600 15px acumin-pro,sans-serif;margin:25px 0 3px}.entry .inner .body .credit a[href^=http]{padding-right:0;background-image:none;border:none}.entry .inner .body .credit a[href^=http]:hover{border-bottom:1px solid #333}.entry .inner .body .tags td{padding-bottom:15px}.entry .inner .body .case-study-link{height:170px;background-size:160px 160px;background-repeat:no-repeat;background-position:bottom left;padding-left:190px;margin:5em auto 1em;line-height:2.3em}.entry .inner .body .case-study-link span:first-child{font-weight:400;font-size:1.2em}.entry .inner .body>hr,.member-list>div:not(:first-child)>hr.line{display:none}.member-list .regions{padding:4px 0 0;margin:0 0 107px;text-align:center;font:normal 300 18px acumin-pro,sans-serif}.member-list .regions li{display:inline-block;list-style:none;margin:0 43px;cursor:pointer;font-size:90%;color:#AAA}.member-list .regions li.selected{color:#000}.member-list .regions li .dot{display:inline-block;width:8px;height:8px;background-color:#000;border-radius:8px;transform:translateY(-15px)}.member-list .regions li .dot.inactive{visibility:hidden}.member{position:relative;display:none}.member.list{display:block;margin-bottom:60px}.member.list .inner{cursor:pointer}.member.open{display:block;margin-bottom:28px}.member.open>div .more{display:block}.member>div{background-position:left top;background-repeat:no-repeat;background-size:350px 350px}.member>div .inner{position:relative;z-index:auto}.member>div .name-title{display:table;width:100%;height:350px;padding-left:350px}.member>div .name-title>div{display:table-cell;text-align:center;vertical-align:middle}.member>div .name-title .title{display:block;font:normal 600 18px acumin-pro,sans-serif;margin:16px auto 10px}.member>div .name-title .title span:first-child{font-weight:700}.member>div .name-title .name-ja{font-size:30px;font-weight:500}.member>div .name-title .name-en{font:normal 300 15px acumin-pro,sans-serif;margin-left:10px}.member>div .name-title .region{display:block;font:normal 300 15px acumin-pro,sans-serif;margin-top:39px}.member>div .more{display:none}.member>div hr.line{margin-left:316px;width:452px}.member>div .body{margin-top:71px;line-height:1.78em}.member>div .body ul{font-size:14px;padding-left:20px}.member>div .body ul li{margin:10px 0}.member>div .links{padding:0;margin-top:25px}.member>div .links li{display:inline-block;margin-right:20px;list-style:none;font-size:15px}.member>div .co-creator{margin:57px auto 0;line-height:1.75em}.member>div .co-creator div:first-child{font-weight:700}.work-item{width:280px;height:202px;margin:0 30px 34px;float:left;text-align:center;background-repeat:no-repeat;background-size:280px 125px}.work-item .inner{position:relative;margin:10px;padding:125px 10px 18px;border:4px solid transparent;cursor:pointer}.work-item .title{margin-bottom:5px;font-size:15px;line-height:1.5em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.work-item .date{font:normal 300 12px acumin-pro,sans-serif}.member-detail h2{font:normal 600 20px acumin-pro,sans-serif;text-align:center;margin:90px auto 80px}.member-detail .works-list{margin:0 -30px}.member-detail .news-list{padding:0 30px;border:none;width:100%}.member-detail .news-list tr{position:relative;display:block;border:4px solid transparent;border-radius:10px;margin-bottom:10px;padding:20px;vertical-align:baseline;background-color:rgba(255,255,255,.97);transform:translateZ(0);cursor:pointer}.member-detail .news-list th{width:150px;padding-right:30px;white-space:nowrap;text-align:right;vertical-align:baseline}.statement{width:960px;margin:auto;text-align:center}.statement img{display:block}.statement .logo{width:868px;margin:168px auto 171px}.statement .logo3{margin:0 auto 140px;font-size:15.3px;line-height:2.4em}.statement .logo3 p{padding-left:12px}.statement .logo3 img{width:50%;display:block;margin:0 auto 40px}.statement .text{width:100%;margin:0 auto 140px}.statement table{text-align:left;font-size:19.5px;line-height:1.95em;border-spacing:0;margin-bottom:55px}.statement table td{padding:0 11px 2px 0}.about .about-text{width:768px;max-width:100%;margin:50px 0}.work-list hr{height:1px;border:none;border-top:1px solid #f0f0f0}.work-list ul.region-list{list-style-type:none;padding:4px 0 0;margin:0 0 24px;text-align:center;font:normal 300 18px acumin-pro,sans-serif}.work-list ul.region-list li{display:inline-block;margin:0 44px;color:#AAA;font-size:90%;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;position:relative}.work-list ul.region-list li.selected{color:#000}.work-list ul.region-list li .dot{display:inline-block;width:8px;height:8px;background-color:#000;border-radius:8px;transform:translateY(-15px)}.work-list ul.region-list li .dot.inactive{visibility:hidden}.work-list ul.tag-list{list-style-type:none;padding:0;margin:25px -5px 0}.work-list ul.tag-list li{display:inline-block;padding:5px 10px;margin:5px;background-color:#f2f2f2;border-radius:5px;font-size:smaller;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;position:relative}.work-list ul.tag-list li.selected{color:#fff;background-color:#666}.work-list .work-items{margin:98px -30px 0}.contact{padding-top:50px}.contact .contact-text1{display:block;width:69.5%;margin:0 0 91px 3px}.contact .contact-text2{display:-ms-flexbox;display:flex;-ms-flex-pack:justify;justify-content:space-between;-ms-flex-align:end;align-items:flex-end;margin-bottom:195px}.contact .contact-text2 img{width:578px}.contact .mail-link{text-align:center}.contact .mail-link a{font:normal 300 18px acumin-pro,sans-serif;display:inline-block;color:#fff;background-color:#000;margin:auto;padding:18px 49px;border:none;border-radius:100px;transform:translateY(6px)}.contact .region{margin:0 auto 90px}.contact .region .name{font:normal 700 30px acumin-pro,sans-serif;margin-bottom:14px}.contact .region th{text-align:left;vertical-align:top;padding:8px 25px 8px 0}@media only screen and (max-width:767px){body{padding:15px 25px 100px;font-size:14px;-webkit-text-size-adjust:100%;letter-spacing:.022em}hr.line{margin:15px 0;height:1px;background-size:480px 1px}#header{margin:58px 0 69px;-ms-flex-pack:center;justify-content:center}#logo a{display:block;width:69%;margin:18px auto 0}#logo a img{width:100%;height:auto}#menu{display:none}#floating-menu{height:auto}#floating-menu>div a{display:block;height:61px;margin:0 15px;padding-top:19px;padding-right:13px;font-size:14px;background-image:url(/assets/line.png);background-size:480px 1px;background-position:bottom;background-repeat:repeat-x}#floating-menu>div a .dot{width:7px;height:7px;transform:translate(-1px,-6px)}#floating-menu>div a:last-child{background:0 0}#menu-button{right:5px;top:5px;transform:none}.statement{width:100%}.statement .logo{margin:-69px auto 54px;width:100%;transform:scale(1.1,1.1)}.statement .logo3{margin:0 auto 84px;width:100%;font-size:11px;line-height:1.95em}.statement .logo3 p{padding-left:0;white-space:nowrap}.statement .logo3 img{width:74%;display:block;margin:22px auto 0}.statement .text{width:96.6%;margin:2px auto 72px}.statement table{margin:0 0 22px 5px;font-size:10.5px;line-height:1.75em}.about .about-text{margin:0 4px 20px;width:96.5%}.entry{margin:0 -25px;padding:0 25px;background-position:0 0}.entry.with-image{padding-top:25px}.entry .inner{border-width:2px;border-radius:6px;padding:0;background-image:none}.entry .inner h1.title{margin-top:10px;margin-bottom:0;font-size:15px}.entry .inner .date{margin-bottom:34px;font-size:11px}.entry .inner .body p,.entry .inner .body table{margin:15px 0}.entry .inner .body .award td,.entry .inner .body .award th,.entry .inner .body .credit td,.entry .inner .body .credit th,.entry .inner .body .tags td,.entry .inner .body .tags th{display:block;text-align:left}.entry .inner .body .award th,.entry .inner .body .credit th,.entry .inner .body .tags th{margin-top:10px;margin-bottom:3px;font-size:14px}.entry .inner .body .award td,.entry .inner .body .credit td,.entry .inner .body .tags td{font-size:12px}.entry .inner .body .award img,.entry .inner .body .credit img,.entry .inner .body .tags img{max-height:30px;margin-right:15px}.entry .inner .body .credit td>span{line-height:1.5;margin-top:4px}.entry .inner .body .case-study-link{background-image:none!important;padding:0;margin:0 0 1.5em;height:auto}.entry .inner .body .tags .work-list ul.tag-list{margin:0 -3px}.entry .inner .body>hr{display:block}.contact{padding:0}.contact .contact-text img{width:93.9%;display:block;margin:0 5px 81px}.contact .mail-link{margin-bottom:78px}.contact .mail-link a{padding:12px 32px;font-size:smaller;transform:none}.contact .region{margin-bottom:58px}.contact .region .name{font-size:19.5px;margin-bottom:24px;margin-left:3px}.contact .region table{font-size:90%;line-height:1.53em}.contact .region table th{padding:0 18px 4px 0;white-space:nowrap}.contact .region table td{padding:0 0 4px}.member-list .regions{margin-top:-10px;margin-bottom:33px;font-size:13px}.member-list .regions li{margin:0 20px 16px}.member-list .regions li .dot{width:4px;height:4px;transform:translateY(-8px)}.member{margin:25px -25px 0}.member.list{margin-bottom:30px}.member.open{margin-bottom:35px}.member>div{padding:15px 15px 0}.member>div .inner{padding:0 15px}.member>div .name-title{height:auto;padding:0}.member>div .name-title .title{font-size:13px;margin-bottom:0}.member>div .name-title .name-ja{display:block;margin-bottom:-10px;font-size:20px}.member>div .name-title .name-en{font-size:11px;margin:0}.member>div .name-title .region{font-size:12px;margin-top:7px}.member>div .more{margin-top:30px}.member>div .more .line{margin:20px auto 0;width:100%}.member>div .more .body{margin-top:0}.member>div .more .links{margin-bottom:0}.work-item{float:none;width:100%;height:auto;margin:0 0 20px;padding:15px}.work-item .inner{margin:0;border-width:2px;border-radius:6px;background-position:-17px -17px}.work-item .title{margin-top:20px;margin-bottom:7px}.member-detail{margin:0}.member-detail h2{margin-bottom:30px}.member-detail .works-list{margin:0 -25px}.member-detail .news-list{padding:0}.member-detail .news-list tr{padding:15px 10px;border-width:2px;border-radius:6px}.member-detail .news-list tr td{display:block;text-align:center}.member-detail .news-list tr th{display:block;width:100%;text-align:center;font-weight:400;font-size:11px;line-height:1.4;margin-bottom:4px}#footer .copyright{position:absolute;left:15px;top:15px;transform-origin:left top}#footer .buttons{z-index:3000;width:100%;left:0;bottom:0;padding:13px;transform:none}#footer .buttons button{float:left;width:31px;height:31px;background-size:31px 31px}#footer .buttons .wallpaper{margin-bottom:0;background-image:url(/assets/wallpaper-sp.png)}#footer .buttons .wallpaper:hover{width:31px;background-image:url(/assets/wallpaper-sp.png)}#footer .buttons .facebook{margin-bottom:0;margin-right:10px;background-image:url(/assets/facebook-sp.png)}#footer .buttons .facebook:hover{background-image:url(/assets/facebook-sp.png)}#footer .buttons .twitter{margin-bottom:0;margin-right:10px;background-image:url(/assets/twitter-sp.png)}#footer .buttons .twitter:hover{background-image:url(/assets/twitter-sp.png)}#footer .buttons .top{position:absolute;right:13px;background-image:url(/assets/top-sp.png)}#footer .buttons .top:hover{background-image:url(/assets/top-sp.png)}.work-list{margin-top:-7px}.work-list ul.region-list{margin:-11px -25px 21px;font-size:13px}.work-list ul.region-list li{margin:0 14px}.work-list ul.region-list li .dot{width:4px;height:4px;transform:translateY(-7px)}.work-list ul.tag-list{margin:22px 0 48px}.work-list ul.tag-list li{padding:3px 6px;margin:3px;font-size:11px}.work-list .work-items{margin:0 -25px}}
+* {
+  box-sizing: border-box;
+  outline: none; }
+
+html {
+  margin: 0;
+  padding: 0; }
+
+body {
+  margin: 0;
+  padding: 40px 40px 100px;
+  color: #333;
+  font: normal 300 17px/1.76 "Noto Sans JP", sans-serif;
+  letter-spacing: 0.053em; }
+
+a {
+  color: #333;
+  text-decoration: none;
+  border-bottom: 1px solid #333; }
+  a:hover, a:visited, a:link, a:active {
+    color: #333; }
+
+a[href^="http"], a[href^="skype"] {
+  padding-right: 14px;
+  background-image: url(/assets/link.png);
+  background-repeat: no-repeat;
+  background-position: right center;
+  background-size: 12px 7px; }
+
+iframe {
+  border: none; }
+
+hr.line {
+  margin: 30px 0;
+  border: none;
+  width: 100%;
+  height: 2px;
+  background-image: url(/assets/line.png); }
+
+#dots {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  opacity: 0.8;
+  z-index: 1000;
+  pointer-events: none; }
+
+#container {
+  position: relative;
+  max-width: 960px;
+  margin: 0 auto; }
+
+.notfound {
+  display: block;
+  text-align: center;
+  margin: 200px 0; }
+
+.clearfix:before,
+.clearfix:after {
+  content: " ";
+  display: table; }
+
+.clearfix:after {
+  clear: both; }
+
+#header {
+  position: relative;
+  z-index: 2000;
+  margin: 20px 0 105px;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: justify;
+      justify-content: space-between; }
+  #header .lang-selector {
+    position: absolute;
+    border: 1px solid black;
+    right: 0;
+    top: 46px;
+    font-size: 13.5px;
+    white-space: nowrap;
+    text-align: center;
+    background-color: white; }
+    #header .lang-selector ul {
+      list-style: none;
+      margin: 10px 20px 10px;
+      padding: 0;
+      line-height: 2.4em;
+      -webkit-user-select: none;
+         -moz-user-select: none;
+          -ms-user-select: none;
+              user-select: none; }
+      #header .lang-selector ul li {
+        cursor: pointer; }
+        #header .lang-selector ul li.current {
+          cursor: default;
+          color: #a6a6a6; }
+
+#logo a {
+  border: none; }
+  #logo a img {
+    width: 180px;
+    margin-top: 5px; }
+
+#menu {
+  padding: 9px 2px 0;
+  margin: 0 -30px; }
+  #menu li {
+    display: inline-block;
+    list-style: none;
+    font: normal 300 17px acumin-pro, sans-serif;
+    margin: 0 19px;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none; }
+    #menu li .dot {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      border-radius: 10px;
+      background-color: black;
+      transform: translateY(-15px); }
+      #menu li .dot.inactive {
+        visibility: hidden; }
+    #menu li a {
+      color: #333;
+      text-decoration: none;
+      border: none; }
+    #menu li.slash {
+      margin: 0 20px 0 18px;
+      transform: translateY(5px); }
+    #menu li.language {
+      font-size: 13.5px;
+      cursor: pointer; }
+      #menu li.language .triangle {
+        display: inline-block;
+        margin: 0 9px 0 7px;
+        width: 0;
+        height: 0;
+        border-style: solid;
+        border-width: 5px 4px 0 4px;
+        border-color: black transparent transparent transparent;
+        transform: translateY(-2px); }
+      #menu li.language .opening {
+        border-width: 0 4px 5px 4px;
+        border-color: transparent transparent black transparent; }
+
+#floating-menu {
+  position: fixed;
+  display: table;
+  z-index: 3000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 80px;
+  padding-bottom: 4px;
+  text-align: center;
+  transition: transform 0.1s ease-out; }
+  #floating-menu > div {
+    display: table-cell;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    vertical-align: middle;
+    background-color: rgba(255, 255, 255, 0.9); }
+    #floating-menu > div a {
+      display: inline-block;
+      list-style: none;
+      font: normal 300 18px acumin-pro, sans-serif;
+      margin: 0 40px;
+      border: none; }
+      #floating-menu > div a .dot {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 10px;
+        background-color: black;
+        transform: translateY(-15px); }
+        #floating-menu > div a .dot.inactive {
+          visibility: hidden; }
+  #floating-menu.close {
+    transform: translateY(-100%); }
+
+#menu-button {
+  position: fixed;
+  z-index: 3100;
+  right: 22px;
+  top: 22px;
+  width: 46px;
+  height: 40px;
+  padding: 10px;
+  cursor: pointer;
+  transform: translateY(-60px);
+  transition: transform 0.2s ease-out;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
+  #menu-button.enable {
+    transform: translateY(0); }
+  #menu-button div {
+    position: absolute;
+    border: 2px solid #333;
+    border-radius: 4px;
+    width: 16px;
+    transition: all 0.1s ease-out; }
+    #menu-button div.upper-left {
+      left: 10px;
+      top: 10px;
+      transform-origin: left top; }
+    #menu-button div.upper-right {
+      right: 10px;
+      top: 10px;
+      transform-origin: right top; }
+    #menu-button div.middle {
+      width: 26px;
+      left: 10px;
+      top: 18px; }
+    #menu-button div.lower-left {
+      left: 10px;
+      bottom: 10px;
+      transform-origin: left bottom; }
+    #menu-button div.lower-right {
+      right: 10px;
+      bottom: 10px;
+      transform-origin: right bottom; }
+  #menu-button.close div {
+    transition: all 0.1s ease-out; }
+  #menu-button.close .upper-left {
+    transform: translateX(6px) rotate(45deg); }
+  #menu-button.close .upper-right {
+    transform: translateX(-6px) rotate(-45deg); }
+  #menu-button.close .middle {
+    transform: scaleX(0); }
+  #menu-button.close .lower-left {
+    transform: translateX(6px) rotate(-45deg); }
+  #menu-button.close .lower-right {
+    transform: translateX(-6px) rotate(45deg); }
+
+#footer .copyright {
+  position: fixed;
+  left: 20px;
+  bottom: 20px;
+  transform-origin: left bottom;
+  transform: scale(0.5, 0.5); }
+#footer .buttons {
+  position: fixed;
+  z-index: auto;
+  right: 20px;
+  bottom: 20px;
+  text-align: right;
+  font-size: 0;
+  transform-origin: right bottom;
+  transform: scale(0.5, 0.5); }
+  #footer .buttons:hover {
+    z-index: 2000; }
+  #footer .buttons button {
+    display: block;
+    width: 68px;
+    height: 68px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    margin: auto 0 auto auto; }
+  #footer .buttons .wallpaper {
+    margin-bottom: 40px;
+    background-position: right;
+    background-image: url(/assets/wallpaper.png); }
+    #footer .buttons .wallpaper:hover {
+      width: 466px;
+      background-image: url(/assets/wallpaper-hover.png); }
+  #footer .buttons .facebook {
+    visibility: hidden;
+    margin-bottom: 20px;
+    background-image: url(/assets/facebook.png); }
+    #footer .buttons .facebook:hover {
+      background-image: url(/assets/facebook-hover.png); }
+  #footer .buttons .twitter {
+    visibility: hidden;
+    margin-bottom: 100px;
+    background-image: url(/assets/twitter.png); }
+    #footer .buttons .twitter:hover {
+      background-image: url(/assets/twitter-hover.png); }
+  #footer .buttons .top {
+    background-image: url(/assets/top.png); }
+    #footer .buttons .top:hover {
+      background-image: url(/assets/top-hover.png); }
+
+.entry {
+  padding: 0 30px;
+  background-repeat: no-repeat;
+  background-position: center top; }
+  .entry.with-image {
+    padding-top: 30px; }
+  .entry .featured-image {
+    height: 396px; }
+  .entry .inner {
+    position: relative;
+    z-index: auto;
+    padding: 40px 62px;
+    background-repeat: no-repeat;
+    background-position: -34px -34px;
+    background-color: transparent;
+    border: 4px solid transparent;
+    border-radius: 10px;
+    overflow: hidden;
+    transform: translateZ(0); }
+    .entry .inner h1.title {
+      margin: 32px auto 12px;
+      font-weight: 400;
+      font-size: 22px;
+      text-align: center; }
+    .entry .inner .date {
+      display: block;
+      margin-bottom: 82px;
+      font: normal 300 15px acumin-pro, sans-serif;
+      text-align: center; }
+      .entry .inner .date a {
+        border: none; }
+    .entry .inner .body {
+      margin: 0 auto;
+      padding: 0;
+      font-weight: 300; }
+      .entry .inner .body img, .entry .inner .body iframe {
+        width: 100%; }
+      .entry .inner .body p, .entry .inner .body table {
+        margin: 20px 0;
+        word-wrap: break-word; }
+      .entry .inner .body .award th, .entry .inner .body .award td, .entry .inner .body .credit th, .entry .inner .body .credit td, .entry .inner .body .tags th, .entry .inner .body .tags td {
+        font-size: 15px;
+        vertical-align: baseline; }
+      .entry .inner .body .award th, .entry .inner .body .credit th, .entry .inner .body .tags th {
+        padding-right: 25px;
+        font: normal 600 15px acumin-pro, sans-serif;
+        text-align: left; }
+      .entry .inner .body .award th, .entry .inner .body .award td {
+        padding-bottom: 10px;
+        vertical-align: middle; }
+      .entry .inner .body .award img {
+        width: auto;
+        max-height: 40px;
+        margin-right: 20px; }
+      .entry .inner .body .credit td > span {
+        display: block; }
+      .entry .inner .body .credit h2 {
+        font: normal 600 15px acumin-pro, sans-serif;
+        margin: 25px 0 3px; }
+      .entry .inner .body .credit a[href^="http"] {
+        padding-right: 0;
+        background-image: none;
+        border: none; }
+        .entry .inner .body .credit a[href^="http"]:hover {
+          border-bottom: 1px solid #333; }
+      .entry .inner .body .tags td {
+        padding-bottom: 15px; }
+      .entry .inner .body .case-study-link {
+        height: 170px;
+        background-size: 160px 160px;
+        background-repeat: no-repeat;
+        background-position: bottom left;
+        padding-left: 190px;
+        margin: 5em auto 1em;
+        line-height: 2.3em; }
+        .entry .inner .body .case-study-link span:first-child {
+          font-weight: 400;
+          font-size: 1.2em; }
+      .entry .inner .body > hr {
+        display: none; }
+
+.member-list > div:not(:first-child) > hr.line {
+  display: none; }
+.member-list .regions {
+  padding: 4px 0 0;
+  margin: 0 0 107px;
+  text-align: center;
+  font: normal 300 18px acumin-pro, sans-serif; }
+  .member-list .regions li {
+    display: inline-block;
+    list-style: none;
+    margin: 0 43px;
+    cursor: pointer;
+    font-size: 90%;
+    color: #AAA; }
+    .member-list .regions li.selected {
+      color: black; }
+    .member-list .regions li .dot {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      background-color: black;
+      border-radius: 8px;
+      transform: translateY(-15px); }
+      .member-list .regions li .dot.inactive {
+        visibility: hidden; }
+
+.member {
+  position: relative;
+  display: none; }
+  .member.list {
+    display: block;
+    margin-bottom: 60px; }
+    .member.list .inner {
+      cursor: pointer; }
+  .member.open {
+    display: block;
+    margin-bottom: 28px; }
+    .member.open > div .more {
+      display: block; }
+  .member > div {
+    background-position: left top;
+    background-repeat: no-repeat;
+    background-size: 350px 350px; }
+    .member > div .inner {
+      position: relative;
+      z-index: auto; }
+    .member > div .name-title {
+      display: table;
+      width: 100%;
+      height: 350px;
+      padding-left: 350px; }
+      .member > div .name-title > div {
+        display: table-cell;
+        text-align: center;
+        vertical-align: middle; }
+      .member > div .name-title .title {
+        display: block;
+        font: normal 600 18px acumin-pro, sans-serif;
+        margin: 16px auto 10px; }
+        .member > div .name-title .title span:first-child {
+          font-weight: bold; }
+      .member > div .name-title .name-ja {
+        font-size: 30px;
+        font-weight: 500; }
+      .member > div .name-title .name-en {
+        font: normal 300 15px acumin-pro, sans-serif;
+        margin-left: 10px; }
+      .member > div .name-title .region {
+        display: block;
+        font: normal 300 15px acumin-pro, sans-serif;
+        margin-top: 39px; }
+    .member > div .more {
+      display: none; }
+    .member > div hr.line {
+      margin-left: 316px;
+      width: 452px; }
+    .member > div .body {
+      margin-top: 71px;
+      line-height: 1.78em; }
+      .member > div .body ul {
+        font-size: 14px;
+        padding-left: 20px; }
+        .member > div .body ul li {
+          margin: 10px 0; }
+    .member > div .links {
+      padding: 0;
+      margin-top: 25px; }
+      .member > div .links li {
+        display: inline-block;
+        margin-right: 20px;
+        list-style: none;
+        font-size: 15px; }
+    .member > div .co-creator {
+      margin: 57px auto 0;
+      line-height: 1.75em; }
+      .member > div .co-creator div:first-child {
+        font-weight: bold; }
+
+.work-item {
+  width: 280px;
+  height: 202px;
+  margin: 0 30px 34px;
+  float: left;
+  text-align: center;
+  background-repeat: no-repeat;
+  background-size: 280px 125px; }
+  .work-item .inner {
+    position: relative;
+    margin: 10px;
+    padding: 125px 10px 18px;
+    border: 4px solid transparent;
+    cursor: pointer; }
+  .work-item .title {
+    margin-bottom: 5px;
+    font-size: 15px;
+    line-height: 1.5em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis; }
+  .work-item .date {
+    font: normal 300 12px acumin-pro, sans-serif; }
+  @media only screen and (max-width: 1060px) and (min-width: 768px) {
+    .work-item {
+      width: calc(50% - 50px);
+      height: auto;
+      margin: 0 25px 34px;
+      test-align: center;
+      background-size: 100% auto;
+      padding: 15px; }
+      .work-item .inner {
+        margin: 10px;
+        padding: 44.6% 10px 18px;
+        border-width: 2px;
+        border-radius: 6px; } }
+
+.member-detail h2 {
+  font: normal 600 20px acumin-pro, sans-serif;
+  text-align: center;
+  margin: 90px auto 80px; }
+.member-detail .works-list {
+  margin: 0 -30px; }
+.member-detail .news-list {
+  padding: 0 30px;
+  border: none;
+  width: 100%; }
+  .member-detail .news-list tr {
+    position: relative;
+    display: block;
+    border: 4px solid transparent;
+    border-radius: 10px;
+    margin-bottom: 10px;
+    padding: 20px;
+    vertical-align: baseline;
+    background-color: rgba(255, 255, 255, 0.97);
+    transform: translateZ(0);
+    cursor: pointer; }
+  .member-detail .news-list th {
+    width: 150px;
+    padding-right: 30px;
+    white-space: nowrap;
+    text-align: right;
+    vertical-align: baseline; }
+
+.statement {
+  width: 960px;
+  margin: auto;
+  margin-top: -50px;
+  text-align: center; }
+  .statement img {
+    display: block; }
+  .statement #showreel {
+    background-color: #000;
+    width: 1280px;
+    height: 720px;
+    margin-left: -160px;
+    position: relative;
+    cursor: pointer; }
+    .statement #showreel img {
+      position: absolute;
+      width: 1280px;
+      height: 720px;
+      top: 0;
+      left: 0; }
+  .statement .logo3 {
+    margin: 96px auto 140px;
+    font-size: 15.3px;
+    line-height: 2.4em; }
+    .statement .logo3 p {
+      padding-left: 12px; }
+    .statement .logo3 img {
+      width: 50%;
+      display: block;
+      margin: 0 auto 40px; }
+  .statement .text {
+    width: 100%;
+    margin: 0 auto 140px; }
+  .statement table {
+    text-align: left;
+    font-size: 19.5px;
+    line-height: 1.95em;
+    border-spacing: 0;
+    margin-bottom: 55px; }
+    .statement table td {
+      padding: 0 11px 2px 0; }
+  .statement #showreel-overlay {
+    display: -ms-flexbox;
+    display: flex;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.9);
+    -ms-flex-align: center;
+        align-items: center;
+    -ms-flex-pack: center;
+        justify-content: center;
+    z-index: 3000; }
+    .statement #showreel-overlay button {
+      margin: 0;
+      padding: 0;
+      background-color: transparent;
+      border: none;
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      transform: scale(0.5, 0.5);
+      transform-origin: top left;
+      cursor: pointer; }
+
+.about .about-text {
+  width: 768px;
+  max-width: 100%;
+  margin: 50px 0 50px; }
+
+.work-list hr {
+  height: 1px;
+  border: none;
+  border-top: 1px solid #f0f0f0; }
+.work-list ul.region-list {
+  list-style-type: none;
+  padding: 4px 0 0;
+  margin: 0 0 24px;
+  text-align: center;
+  font: normal 300 18px acumin-pro, sans-serif; }
+  .work-list ul.region-list li {
+    display: inline-block;
+    margin: 0 44px;
+    color: #AAA;
+    font-size: 90%;
+    cursor: pointer;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    position: relative; }
+    .work-list ul.region-list li.selected {
+      color: black; }
+    .work-list ul.region-list li .dot {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      background-color: black;
+      border-radius: 8px;
+      transform: translateY(-15px); }
+      .work-list ul.region-list li .dot.inactive {
+        visibility: hidden; }
+.work-list ul.tag-list {
+  list-style-type: none;
+  padding: 0;
+  margin: 25px -5px 0; }
+  .work-list ul.tag-list li {
+    display: inline-block;
+    padding: 5px 10px;
+    margin: 5px;
+    background-color: #f2f2f2;
+    border-radius: 5px;
+    font-size: smaller;
+    cursor: pointer;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    position: relative; }
+    .work-list ul.tag-list li.selected {
+      color: white;
+      background-color: #666666; }
+.work-list .work-items {
+  margin: 98px -30px 0; }
+
+.contact {
+  padding-top: 50px; }
+  .contact .contact-text1 {
+    display: block;
+    width: 69.5%;
+    margin: 0 0 91px 3px; }
+  .contact .contact-text2 {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-pack: justify;
+        justify-content: space-between;
+    -ms-flex-align: end;
+        align-items: flex-end;
+    margin-bottom: 195px; }
+    .contact .contact-text2 img {
+      width: 578px; }
+  .contact .mail-link {
+    text-align: center; }
+    .contact .mail-link a {
+      font: normal 300 18px acumin-pro, sans-serif;
+      display: inline-block;
+      color: white;
+      background-color: black;
+      margin: auto;
+      padding: 18px 49px;
+      border: none;
+      border-radius: 100px;
+      transform: translateY(6px); }
+  .contact .region {
+    margin: 0 auto 90px; }
+    .contact .region .name {
+      font: normal 700 30px acumin-pro, sans-serif;
+      margin-bottom: 14px; }
+    .contact .region th {
+      text-align: left;
+      vertical-align: top;
+      padding: 8px 25px 8px 0; }
+
+@media only screen and (max-width: 900px) {
+  body {
+    padding: 15px 25px 100px;
+    font-size: 14px;
+    -webkit-text-size-adjust: 100%;
+    letter-spacing: 0.022em; }
+
+  hr.line {
+    margin: 15px 0;
+    height: 1px;
+    background-size: 480px 1px; }
+
+  #header {
+    margin: 58px 0 69px;
+    -ms-flex-pack: center;
+        justify-content: center; }
+
+  #logo a {
+    display: block;
+    width: 69%;
+    margin: 18px auto 0; }
+    #logo a img {
+      width: 100%;
+      height: auto; }
+
+  #menu {
+    display: none; }
+
+  #floating-menu {
+    height: auto;
+    display: block; }
+    #floating-menu > div {
+      display: block; }
+    #floating-menu > div a {
+      display: block;
+      height: 61px;
+      margin: 0 15px;
+      padding-top: 20px;
+      padding-right: 13px;
+      font-size: 14px;
+      background-image: url(/assets/line.png);
+      background-size: 480px 1px;
+      background-position: bottom;
+      background-repeat: repeat-x; }
+      #floating-menu > div a .dot {
+        width: 7px;
+        height: 7px;
+        transform: translate(-1px, -6px); }
+      #floating-menu > div a:last-child {
+        background: none; }
+    #floating-menu .language-selector {
+      border-top: 1px solid #ccc; }
+      #floating-menu .language-selector ul {
+        list-style: none;
+        font-size: 11px;
+        margin: 0;
+        padding: 22px 0; }
+        #floating-menu .language-selector ul li {
+          display: inline-block;
+          margin: 0 9px; }
+          #floating-menu .language-selector ul li.current {
+            color: #a6a6a6; }
+
+  #menu-button {
+    right: 5px;
+    top: 5px;
+    transform: none; }
+
+  .statement {
+    width: 100%; }
+    .statement .logo {
+      margin: -69px auto 54px;
+      width: 100%;
+      transform: scale(1.1, 1.1); }
+    .statement .logo3 {
+      margin: 0 auto 54px;
+      width: 100%;
+      font-size: 11px;
+      line-height: 1.95em; }
+      .statement .logo3 p {
+        padding-left: 0;
+        white-space: nowrap; }
+      .statement .logo3 img {
+        width: 74%;
+        display: block;
+        margin: 22px auto 22px; }
+    .statement .text {
+      width: 96.6%;
+      margin: 2px auto 72px; }
+    .statement table {
+      margin: 0 0 22px 5px;
+      font-size: 10.5px;
+      line-height: 1.75em; }
+    .statement #showreel {
+      width: calc(100% + 50px);
+      height: 450px;
+      overflow: hidden;
+      margin-left: -25px;
+      margin-bottom: 60px; }
+      .statement #showreel div {
+        width: 100%;
+        height: 100%;
+        overflow: hidden; }
+        .statement #showreel div video {
+          width: auto;
+          height: 100%; }
+      .statement #showreel img {
+        width: auto;
+        height: 100%; }
+
+  .about .about-text {
+    margin: 0 4px 20px;
+    width: 96.5%; }
+
+  .entry {
+    margin: 0 -25px;
+    padding: 0 25px;
+    background-position: 0 0; }
+    .entry.with-image {
+      padding-top: 25px; }
+    .entry .inner {
+      border-width: 2px;
+      border-radius: 6px;
+      padding: 0;
+      background-image: none; }
+      .entry .inner h1.title {
+        margin-top: 10px;
+        margin-bottom: 0;
+        font-size: 15px; }
+      .entry .inner .date {
+        margin-bottom: 34px;
+        font-size: 11px; }
+      .entry .inner .body p, .entry .inner .body table {
+        margin: 15px 0; }
+      .entry .inner .body .award th, .entry .inner .body .award td, .entry .inner .body .credit th, .entry .inner .body .credit td, .entry .inner .body .tags th, .entry .inner .body .tags td {
+        display: block;
+        text-align: left; }
+      .entry .inner .body .award th, .entry .inner .body .credit th, .entry .inner .body .tags th {
+        margin-top: 10px;
+        margin-bottom: 3px;
+        font-size: 14px; }
+      .entry .inner .body .award td, .entry .inner .body .credit td, .entry .inner .body .tags td {
+        font-size: 12px; }
+      .entry .inner .body .award img, .entry .inner .body .credit img, .entry .inner .body .tags img {
+        max-height: 30px;
+        margin-right: 15px; }
+      .entry .inner .body .credit td > span {
+        line-height: 1.5;
+        margin-top: 4px; }
+      .entry .inner .body .case-study-link {
+        background-image: none !important;
+        padding: 0;
+        margin: 0;
+        margin-bottom: 1.5em;
+        height: auto; }
+      .entry .inner .body .tags .work-list ul.tag-list {
+        margin: 0 -3px 0; }
+      .entry .inner .body > hr {
+        display: block; }
+
+  .contact {
+    padding: 0; }
+    .contact .contact-text img {
+      width: 93.9%;
+      display: block;
+      margin: 0 5px 81px; }
+    .contact .mail-link {
+      margin-bottom: 78px; }
+      .contact .mail-link a {
+        padding: 12px 32px;
+        font-size: smaller;
+        transform: none; }
+    .contact .region {
+      margin-bottom: 58px; }
+      .contact .region .name {
+        font-size: 19.5px;
+        margin-bottom: 24px;
+        margin-left: 3px; }
+      .contact .region table {
+        font-size: 90%;
+        line-height: 1.53em; }
+        .contact .region table th {
+          padding: 0 18px 4px 0;
+          white-space: nowrap; }
+        .contact .region table td {
+          padding: 0 0 4px; }
+
+  .member-list .regions {
+    margin-top: -10px;
+    margin-bottom: 33px;
+    font-size: 13px; }
+    .member-list .regions li {
+      margin: 0 20px 16px; }
+      .member-list .regions li .dot {
+        width: 4px;
+        height: 4px;
+        transform: translateY(-8px); } }
+@media only screen and (max-width: 900px) and (max-width: 900px) and (min-width: 768px) {
+  .member > div .name-title .title {
+    font-size: 13px; }
+  .member > div .name-title .name-ja {
+    font-size: 20px; }
+  .member > div .name-title .name-en {
+    font-size: 11px; }
+  .member > div .name-title .region {
+    font-size: 12px; } }
+@media only screen and (max-width: 900px) and (max-width: 767px) {
+  .member {
+    margin: 25px -25px 0; }
+    .member.list {
+      margin-bottom: 30px; }
+    .member.open {
+      margin-bottom: 35px; }
+    .member > div {
+      padding: 15px;
+      padding-bottom: 0; }
+      .member > div .inner {
+        padding: 0 15px; }
+      .member > div .name-title {
+        height: auto;
+        padding: 0; }
+        .member > div .name-title .title {
+          font-size: 13px;
+          margin-bottom: 0; }
+        .member > div .name-title .name-ja {
+          display: block;
+          margin-bottom: -10px;
+          font-size: 20px; }
+        .member > div .name-title .name-en {
+          font-size: 11px;
+          margin: 0; }
+        .member > div .name-title .region {
+          font-size: 12px;
+          margin-top: 7px; }
+      .member > div .more {
+        margin-top: 30px; }
+        .member > div .more .line {
+          margin: 20px auto 0;
+          width: 100%; }
+        .member > div .more .body {
+          margin-top: 0; }
+        .member > div .more .links {
+          margin-bottom: 0; } }
+
+@media only screen and (max-width: 900px) and (max-width: 767px) {
+  .work-item {
+    float: none;
+    width: 100%;
+    height: auto;
+    margin: 0 0 20px;
+    padding: 15px; }
+    .work-item .inner {
+      margin: 0;
+      border-width: 2px;
+      border-radius: 6px;
+      background-position: -17px -17px; }
+    .work-item .title {
+      margin-top: 20px;
+      margin-bottom: 7px; } }
+
+@media only screen and (max-width: 900px) {
+  .member-detail {
+    margin: 0; }
+    .member-detail h2 {
+      margin-bottom: 30px; }
+    .member-detail .works-list {
+      margin: 0 -25px; }
+    .member-detail .news-list {
+      padding: 0; }
+      .member-detail .news-list tr {
+        padding: 15px 10px;
+        border-width: 2px;
+        border-radius: 6px; }
+        .member-detail .news-list tr td {
+          display: block;
+          text-align: center; }
+        .member-detail .news-list tr th {
+          display: block;
+          width: 100%;
+          text-align: center;
+          font-weight: normal;
+          font-size: 11px;
+          line-height: 1.4;
+          margin-bottom: 4px; }
+
+  #footer .copyright {
+    position: absolute;
+    left: 15px;
+    top: 15px;
+    transform-origin: left top; }
+  #footer .buttons {
+    z-index: 3000;
+    width: 100%;
+    left: 0;
+    bottom: 0;
+    padding: 13px;
+    transform: none; }
+    #footer .buttons button {
+      float: left;
+      width: 31px;
+      height: 31px;
+      background-size: 31px 31px; }
+    #footer .buttons .wallpaper {
+      margin-bottom: 0;
+      background-image: url(/assets/wallpaper-sp.png); }
+      #footer .buttons .wallpaper:hover {
+        width: 31px;
+        background-image: url(/assets/wallpaper-sp.png); }
+    #footer .buttons .facebook {
+      visibility: hidden;
+      margin-bottom: 0;
+      margin-right: 10px;
+      background-image: url(/assets/facebook-sp.png); }
+      #footer .buttons .facebook:hover {
+        background-image: url(/assets/facebook-sp.png); }
+    #footer .buttons .twitter {
+      visibility: hidden;
+      margin-bottom: 0;
+      margin-right: 10px;
+      background-image: url(/assets/twitter-sp.png); }
+      #footer .buttons .twitter:hover {
+        background-image: url(/assets/twitter-sp.png); }
+    #footer .buttons .top {
+      position: absolute;
+      right: 13px;
+      background-image: url(/assets/top-sp.png); }
+      #footer .buttons .top:hover {
+        background-image: url(/assets/top-sp.png); } }
+@media only screen and (max-width: 900px) and (max-width: 767px) {
+  .work-list {
+    margin-top: -7px; }
+    .work-list ul.region-list {
+      margin: -11px -25px 21px;
+      font-size: 13px; }
+      .work-list ul.region-list li {
+        margin: 0 14px; }
+        .work-list ul.region-list li .dot {
+          width: 4px;
+          height: 4px;
+          transform: translateY(-7px); }
+    .work-list ul.tag-list {
+      margin: 22px 0 48px; }
+      .work-list ul.tag-list li {
+        padding: 3px 6px;
+        margin: 3px;
+        font-size: 11px; }
+    .work-list .work-items {
+      margin: 0 -25px; } }

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,6 +1,6 @@
 var React = require('react')
 var MobileDetect = require('mobile-detect')
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile()
+var isMobile = !!new MobileDetect(navigator.userAgent).phone()
 
 var Lang = require('./Lang')
 

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,6 +1,6 @@
 var React = require('react');
 var MobileDetect = require('mobile-detect')
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile()
+var isMobile = !!new MobileDetect(navigator.userAgent).phone()
 var ClipboardJS = require('clipboard')
 
 var Lang = require('./Lang')

--- a/src/components/Entry.jsx
+++ b/src/components/Entry.jsx
@@ -4,7 +4,7 @@ var Router = require('react-router')
 var { Navigation } = Router
 var $ = require('jquery')
 var MobileDetect = require('mobile-detect')
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile()
+var isMobile = !!new MobileDetect(navigator.userAgent).phone()
 var moment = require('moment')
 moment.locale('en')
 var Baby = require('babyparse')

--- a/src/components/EntryList.jsx
+++ b/src/components/EntryList.jsx
@@ -4,7 +4,7 @@ var {State} = Route;
 var DocumentTitle = require('react-document-title');
 var $ = require('jquery');
 var MobileDetect = require('mobile-detect');
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile();
+var isMobile = !!new MobileDetect(navigator.userAgent).phone();
 
 var Entry = require('./Entry');
 var Lang = require('./Lang');

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ var Router = require('react-router')
 var { State, Navigation } = Router
 var _ = require('underscore')
 var MobileDetect = require('mobile-detect')
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile()
+var isMobile = !!new MobileDetect(navigator.userAgent).phone()
 
 var Link = require('./Link')
 var MenuData = require('../data').menu

--- a/src/components/MemberList.jsx
+++ b/src/components/MemberList.jsx
@@ -7,7 +7,7 @@ var DocumentTitle = require('react-document-title')
 var $ = require('jquery')
 var _ = require('underscore')
 var MobileDetect = require('mobile-detect')
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile()
+var isMobile = !!new MobileDetect(navigator.userAgent).phone()
 
 var Lang = require('./Lang')
 
@@ -32,19 +32,26 @@ var Member = React.createClass({
 
     _onResize() {
         var w = window.innerWidth
-        var h = w
-        $(this.refs.portrait.getDOMNode()).css('background-size', `${w}px ${h}px`)
-        $(this.refs.inner.getDOMNode()).css({
-            'padding-top': h - 13,
-            'background-size': `${w}px ${h}px`
-        })
+        if (w<768) {
+            var h = w
+            $(this.refs.portrait.getDOMNode()).css('background-size', `${w}px ${h}px`)
+            $(this.refs.inner.getDOMNode()).css({
+                'padding-top': h - 13,
+                'background-size': `${w}px ${h}px`
+            })
+        }
+        else
+        {
+            $(this.refs.portrait.getDOMNode()).css('background-size', '')
+            $(this.refs.inner.getDOMNode()).css({'padding-top': '','background-size': ''})
+        }
     },
 
     componentDidMount() {
-        if (isMobile) {
+        //if (isMobile) {
             $(window).on('resize', this._onResize)
             this._onResize()
-        }
+        //}
         $('a', this.refs.body.getDOMNode()).on('click', this._onClickLink)
     },
 

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -7,7 +7,7 @@ var _ = require('underscore')
 require('browsernizr/test/touchevents')
 var Modernizr = require('browsernizr')
 var MobileDetect = require('mobile-detect')
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile()
+var isMobile = !!new MobileDetect(navigator.userAgent).phone()
 
 var Link = require('./Link')
 var MenuData = require('../data').menu

--- a/src/components/Page.jsx
+++ b/src/components/Page.jsx
@@ -4,7 +4,7 @@ var Router = require('react-router');
 var {State, Navigation} = Router;
 var DocumentTitle = require('react-document-title');
 var MobileDetect = require('mobile-detect');
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile();
+var isMobile = !!new MobileDetect(navigator.userAgent).phone();
 var moment = require('moment');
 moment.locale('en');
 var $ = require('jquery');

--- a/src/components/Single.jsx
+++ b/src/components/Single.jsx
@@ -4,7 +4,7 @@ var {State} = Router;
 var DocumentTitle = require('react-document-title');
 var $ = require('jquery');
 var MobileDetect = require('mobile-detect');
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile();
+var isMobile = !!new MobileDetect(navigator.userAgent).phone();
 
 var Entry = require('./Entry');
 var NotFound = require('./NotFound');

--- a/src/components/Statement.jsx
+++ b/src/components/Statement.jsx
@@ -1,6 +1,6 @@
 var React = require('react')
 var MobileDetect = require('mobile-detect')
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile()
+var isMobile = !!new MobileDetect(navigator.userAgent).phone()
 
 var Lang = require('./Lang')
 

--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -3,7 +3,7 @@ var Router = require('react-router');
 var {State, Navigation} = Router;
 var $ = require('jquery');
 var MobileDetect = require('mobile-detect');
-var isMobile = !!new MobileDetect(navigator.userAgent).mobile();
+var isMobile = !!new MobileDetect(navigator.userAgent).phone();
 var moment = require('moment');
 moment.locale('en');
 
@@ -19,18 +19,25 @@ module.exports = React.createClass({
     },
 
     _onResize() {
-        var width = $(window).width();
-        var h = ~~(width / 960 * 430);
-        var style = {backgroundSize: `${width}px ${h}px`};
-        $(this.refs.work.getDOMNode()).css(style);
-        $(this.refs.inner.getDOMNode()).css(style).css('padding-top', h - 17);
+        var width = window.innerWidth;
+        if (width<768) {
+            var h = ~~(width / 960 * 430);
+            var style = {backgroundSize: `${width}px ${h}px`};
+            $(this.refs.work.getDOMNode()).css(style);
+            $(this.refs.inner.getDOMNode()).css(style).css('padding-top', h - 17);
+        }
+        else
+        {
+            $(this.refs.work.getDOMNode()).css('backgroundSize', '');
+            $(this.refs.inner.getDOMNode()).css('backgroundSize', '').css('padding-top', '');
+        }
     },
 
     componentDidMount() {
-        if (isMobile) {
+        //if (isMobile) {
             $(window).on('resize', this._onResize);
             this._onResize();
-        }
+        //}
     },
 
     componentWillUnmount() {

--- a/src/main.sass
+++ b/src/main.sass
@@ -86,5 +86,5 @@ hr.line
 @import "styles/work-list"
 @import "styles/contact"
 
-@media only screen and (max-width: 767px)
+@media only screen and (max-width: 900px)
   @import "styles/mobile"

--- a/src/styles/member-detail.sass
+++ b/src/styles/member-detail.sass
@@ -22,6 +22,18 @@
   .date
     font: normal 300 12px acumin-pro, sans-serif
 
+  @media only screen and (max-width: 1060px) and (min-width: 768px)
+    width: calc(50% - 50px)
+    height: auto
+    margin: 0 25px 34px
+    test-align: center
+    background-size: 100% auto
+    padding: 15px
+    .inner
+      margin: 10px
+      padding: 44.6% 10px 18px // h125 / w280 * 100
+      border-width: 2px
+      border-radius: 6px
 
 .member-detail
 

--- a/src/styles/mobile.sass
+++ b/src/styles/mobile.sass
@@ -213,60 +213,74 @@ hr.line
         transform: translateY(-8px)
 
 .member
-  margin: 25px -25px 0
-  &.list
-    margin-bottom: 30px
-  &.open
-    margin-bottom: 35px
+  @media only screen and (max-width: 900px) and (min-width: 768px)
+    > div
+      .name-title
+        .title
+          font-size: 13px
+        .name-ja
+          font-size: 20px
+        .name-en
+          font-size: 11px
+        .region
+          font-size: 12px
 
-  > div
-    padding: 15px
-    padding-bottom: 0
+  @media only screen and (max-width: 767px)
+    margin: 25px -25px 0
+    &.list
+      margin-bottom: 30px
+    &.open
+      margin-bottom: 35px
 
-    .inner
-      padding: 0 15px
+    > div
+      padding: 15px
+      padding-bottom: 0
 
-    .name-title
-      height: auto
-      padding: 0
-      .title
-        font-size: 13px
-        margin-bottom: 0
-      .name-ja
-        display: block
-        margin-bottom: -10px
-        font-size: 20px
-      .name-en
-        font-size: 11px
-        margin: 0
-      .region
-        font-size: 12px
-        margin-top: 7px
+      .inner
+        padding: 0 15px
 
-    .more
-      margin-top: 30px
-      .line
-        margin: 20px auto 0
-        width: 100%
-      .body
-        margin-top: 0
-      .links
-        margin-bottom: 0
+      .name-title
+        height: auto
+        padding: 0
+        .title
+          font-size: 13px
+          margin-bottom: 0
+        .name-ja
+          display: block
+          margin-bottom: -10px
+          font-size: 20px
+        .name-en
+          font-size: 11px
+          margin: 0
+        .region
+          font-size: 12px
+          margin-top: 7px
+
+      .more
+        margin-top: 30px
+        .line
+          margin: 20px auto 0
+          width: 100%
+        .body
+          margin-top: 0
+        .links
+          margin-bottom: 0
 
 .work-item
-  float: none
-  width: 100%
-  height: auto
-  margin: 0 0 20px
-  padding: 15px
-  .inner
-    margin: 0
-    border-width: 2px
-    border-radius: 6px
-    background-position: -17px -17px
-  .title
-    margin-top: 20px
-    margin-bottom: 7px
+  @media only screen and (max-width: 767px)
+    float: none
+    width: 100%
+    height: auto
+    margin: 0 0 20px
+    padding: 15px
+    .inner
+      margin: 0
+      border-width: 2px
+      border-radius: 6px
+      background-position: -17px -17px
+    .title
+      margin-top: 20px
+      margin-bottom: 7px
 
 .member-detail
   margin: 0
@@ -340,21 +354,22 @@ hr.line
         background-image: url(/assets/top-sp.png)
 
 .work-list
-  margin-top: -7px
-  ul.region-list
-    margin: -11px -25px 21px
-    font-size: 13px
-    li
-      margin: 0 14px
-      .dot
-        width: 4px
-        height: 4px
-        transform: translateY(-7px)
-  ul.tag-list
-    margin: 22px 0 48px
-    li
-      padding: 3px 6px
-      margin: 3px
-      font-size: 11px
-  .work-items
-    margin: 0 -25px
+  @media only screen and (max-width: 767px)
+    margin-top: -7px
+    ul.region-list
+      margin: -11px -25px 21px
+      font-size: 13px
+      li
+        margin: 0 14px
+        .dot
+          width: 4px
+          height: 4px
+          transform: translateY(-7px)
+    ul.tag-list
+      margin: 22px 0 48px
+      li
+        padding: 3px 6px
+        margin: 3px
+        font-size: 11px
+    .work-items
+      margin: 0 -25px


### PR DESCRIPTION
■作業内容
・タブレット = PCサイトを表示。PCをレスポンシブに。
・スマホの分岐を !!new MobileDetect(navigator.userAgent).mobile() -> phone() に変更

【PC、タブレット】
・w1061px以上 … 通常通りPC表示
・w1060〜901px … WORK一覧が二列
・w900px〜768px … グロナビがハンバーガーに変化、TEAMの文字サイズ小さく
・w767px以下 … WORK一覧が一列、TEAM一覧・詳細が一列

■ファイル修正内容
・main.sass のブレイクポイント指定を 767px -> 900px に変更
・mobile.sass の768〜900px時の処理追加
・member-detail.sass に768〜1060px時の処理追加
・WorkItem.jsx のOnResizeまわり、モバイルでの分岐を横幅での分岐に変更。
・MemberList.jsx のOnResizeまわり、モバイルでの分岐を横幅での分岐に変更。
・各jsxの !!new MobileDetect(navigator.userAgent).mobile() を phone() に変更。

ご確認をお願いします。